### PR TITLE
feat: adicionar execução manual ao workflow ci-build-test

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -14,6 +14,13 @@ on:
       - 'src/**'
       - 'package*.json'
       - 'tsconfig.json'
+  workflow_dispatch:
+    inputs:
+      run_full_suite:
+        description: 'Run full test suite including linting'
+        required: false
+        type: boolean
+        default: true
 
 env:
   NODE_VERSION: '22'
@@ -130,3 +137,4 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Branch:** `${{ github.ref_name }}`" >> $GITHUB_STEP_SUMMARY
           echo "**Commit:** `${{ github.sha }}`" >> $GITHUB_STEP_SUMMARY
+


### PR DESCRIPTION
- Adicionar workflow_dispatch ao ci-build-test.yml para execução manual
- Incluir input run_full_suite para controle opcional dos testes
- Permite validar código Lambda antes de push/PR
- Completa correções de workflows para execução manual em todos os repositórios

Fixes: ci-build-test não podia ser executado manualmente