### PR TITLE
feat: add S3 backend configuration for Terraform state

### DIFF
--- a/.github/workflows/infrastructure-deploy-lambda.yml
+++ b/.github/workflows/infrastructure-deploy-lambda.yml
@@ -26,7 +26,7 @@ on:
 env:
   AWS_REGION: us-east-1
   LAMBDA_FUNCTION_NAME: fast-food-auth
-  TF_VERSION: '1.0'
+  TF_VERSION: '1.5.0'
 
 jobs:
   terraform-plan:

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -10,6 +10,12 @@ terraform {
     }
   }
   required_version = ">= 1.0"
+
+  backend "s3" {
+    bucket = "fastfood-terraform-state-bucket"
+    key    = "lambda/terraform.tfstate"
+    region = "us-east-1"
+  }
 }
 
 provider "aws" {


### PR DESCRIPTION
- Add S3 backend configuration to store Terraform state remotely
- Use bucket: fastfood-terraform-state-bucket
- Key: lambda/terraform.tfstate (specific for lambda infrastructure)
- Region: us-east-1

This enables state sharing and prevents conflicts between deployments